### PR TITLE
Harden tournament ownership and fixture validation

### DIFF
--- a/engine/tournament_engine.py
+++ b/engine/tournament_engine.py
@@ -196,17 +196,15 @@ class TournamentEngine:
             db.session.flush()
 
             # 2. Add Teams to Tournament
-            # Verify teams exist before adding
-            Teams = db.session.query(TournamentTeam.team_id).filter(TournamentTeam.id.in_(team_ids)).all()
-            # Actually we need to check the Teams table, not TournamentTeam (circular logic error in head, reading code)
-            # Re-reading code: The Review said "Verify Team IDs actually exist in database".
-            
-            # Correct logic:
-            existing_teams = Team.query.filter(Team.id.in_(team_ids)).all()
+            # Verify teams exist and belong to the user before adding.
+            existing_teams = Team.query.filter(
+                Team.id.in_(team_ids),
+                Team.user_id == user_id
+            ).all()
             if len(existing_teams) != len(team_ids):
                 found_ids = {t.id for t in existing_teams}
                 missing = set(team_ids) - found_ids
-                raise ValueError(f"Teams with IDs {missing} do not exist.")
+                raise ValueError(f"Teams with IDs {missing} are not available for this user.")
 
             for tid in team_ids:
                 existing = TournamentTeam.query.filter_by(

--- a/tournament_module_review.md
+++ b/tournament_module_review.md
@@ -1,0 +1,20 @@
+# Tournament Module Review
+
+This document summarizes potential issues discovered in the tournament module across engine logic, route handling, data integrity, and UX.
+
+## Scope
+- `engine/tournament_engine.py`
+- `app.py` (tournament routes + match save flow)
+- `database/models.py`
+- `match_archiver.py`
+- Tournament templates (rendering behavior in `app.py`)
+
+## Findings (highlights)
+- Placeholder team IDs (BYE/TBD) are hard-coded and can collide with real teams.
+- Tournament ownership and fixture/tournament IDs are not consistently validated at the API boundary.
+- Knockout and playoff progression can proceed with missing winners.
+- Standings updates are not idempotent and may double count in some flows.
+- Resimulation only resets league stats; knockout fixtures and downstream fixtures are not fully reset.
+- Standings ordering in the UI differs from engine tie-breakers.
+
+See the interview response for the full line-by-line analysis.


### PR DESCRIPTION
### Motivation
- Close ownership and validation gaps that could allow cross-user tournament/team usage and incorrect standings updates by enforcing ownership checks at API and engine boundaries.
- Prevent mismatches between submitted fixtures/teams and stored tournament fixtures to avoid accidental or malicious data corruption.

### Description
- In `app.py` enforced team ownership in `create_tournament_route` by verifying selected `team_ids` are owned by `current_user` and returning an error if not.
- In the match save flow in `app.py` added `req_fixture_id`/`req_tournament_id` validation to ensure the referenced `TournamentFixture` or `Tournament` belongs to `current_user` and that fixture teams match the submitted teams, returning `403`/`400` where appropriate.
- In `engine/tournament_engine.py` tightened `create_tournament` team verification to only accept `Team` rows with `Team.user_id == user_id` and return a clear error for missing or unauthorized team IDs.
- In `match_archiver.py` imported `Tournament` and added an ownership check before calling `TournamentEngine.update_standings`, skipping the update and logging a warning when the match owner and tournament owner differ.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976e3df21588330899c42a7f6185155)