### PR TITLE
Fix run-out strike rotation when striker is dismissed

### DIFF
--- a/engine/match.py
+++ b/engine/match.py
@@ -4570,6 +4570,19 @@ class Match:
                     }
             self.remaining_batter_indices.discard(provisional_index)
             self._bring_new_batter(dismissed_end, provisional_index)
+            # Run-Out cross handling: a run-out implies 1 completed run before
+            # the dismissal, so the batters had physically crossed. When the
+            # original striker was dismissed, the surviving non-striker is now
+            # at the striker end and the new batter takes the non-striker end.
+            # _bring_new_batter("striker", ...) does not account for the cross
+            # (it just replaces current_striker), so swap pointers here.
+            # The "non_striker" branch of _bring_new_batter already handles the
+            # cross correctly via its own swap, so no fix-up is needed there.
+            if wicket_type == "Run Out" and dismissed_end == "striker":
+                self.current_striker, self.current_non_striker = (
+                    self.current_non_striker, self.current_striker
+                )
+                self.batter_idx.reverse()
             commentary_line += f"<br>{self.current_striker['name']} walks in next."
             if self._is_manual_mode():
                 pending_decision_for_response = {


### PR DESCRIPTION
## Summary
- Run-Out + `dismissed_end == "striker"` was leaving the surviving batter at the non-striker end and putting the new batter on strike. Cricket says the opposite: 1 run was completed before the dismissal, the batters crossed, the surviving batter is on strike.
- After `_bring_new_batter` returns, swap `current_striker` / `current_non_striker` and reverse `batter_idx` when the dismissal was Run Out + striker.
- The `"non_striker"` path through `_bring_new_batter` already handles the cross correctly (its existing swap logic implicitly accounts for it), so no fix-up is needed there.
- Super-over run-outs already handle the cross via the `so_crossed` flag at [engine/match.py:5443](engine/match.py#L5443) — unchanged.
- The non-run-out wicket branch sets `dismissed_end = "striker"` unconditionally, but the `wicket_type == "Run Out"` gate ensures Bowled / Caught / LBW / Stumped (no cross) are unaffected.

## Trace
- Before ball: striker=A, non-striker=B. A faces.
- 1 run completed → physically A at non-striker end, B at striker end.
- Run Out dismisses A (engine label `"striker"`). New batter X comes in.
- Correct final state: `current_striker = B` (was at striker end after cross), `current_non_striker = X` (takes A's old physical end).
- Pre-fix state: `current_striker = X`, `current_non_striker = B` — wrong batter facing the next ball.

## Test plan
- [ ] Run a T20 sim end-to-end and confirm it completes without errors.
- [ ] Trigger a run-out before ball 6 of an over and verify the surviving batter (not the new one) faces the next delivery.
- [ ] Run a super-over scenario and confirm the existing `so_crossed` path still produces correct strike on a run-out.
- [ ] Confirm Bowled / Caught / LBW / Stumped dismissals still bring the new batter to the striker end (no regression on non-run-out paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect batsman positioning following a run-out where the striker is dismissed, ensuring proper assignment of batsmen to their correct ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->