### PR TITLE
fix(super-over): harden against freezes, dead-ends, and state corruption

### DIFF
--- a/engine/match.py
+++ b/engine/match.py
@@ -3673,6 +3673,19 @@ class Match:
         return f"<em>{commentary}</em>" if commentary else None
 
     def next_ball(self):
+        # Super Over guard: once a tie pushes the match into super-over state
+        # (innings 4 = super over pending/in progress, 5 = decided), the normal
+        # ball loop must NOT run. Without this guard a stray next_ball() — from a
+        # page refresh/resume or a duplicated client loop — falls through to the
+        # second-innings-end branch and corrupts the result. Return a safe signal
+        # so the frontend can route to the super-over flow instead of looping.
+        if self.innings >= 4:
+            return {
+                "super_over_in_progress": True,
+                "match_over": self.innings == 5,
+                "result": getattr(self, "result", None),
+            }
+
         if self.innings == 3:
 
             self._save_second_innings_stats()

--- a/static/js/match_detail.js
+++ b/static/js/match_detail.js
@@ -1078,6 +1078,27 @@ function _processBallResult(data) {
         updateScoreBanner(data);
     }
 
+    // Super Over guard signal from the engine: the match is in super-over state
+    // but a NORMAL ball request arrived (stray resume/duplicate loop). Stop the
+    // normal loop so it can't spin on empty responses or corrupt state.
+    if (data.super_over_in_progress) {
+        if (data.match_over) {
+            // Super over already decided — send the user to the final scoreboard.
+            matchOver = true;
+            const mid = matchData.match_id;
+            appendLog(`══ ${data.result || 'Super Over complete'} ══`, 'comment');
+            setTimeout(() => { window.location.href = `/match/${mid}/scoreboard`; }, 1200);
+        } else {
+            // Super over still in progress and cannot be resumed inline yet.
+            appendLog(
+                '<span style="color:#f59e0b;font-weight:700;">⚠ Super Over in progress</span> — ' +
+                'please reload the page to continue from the Super Over panel.',
+                'comment'
+            );
+        }
+        return; // never schedule another normal ball
+    }
+
     // Win probability meter (2nd innings only)
     updateWinProbBanner(data);
 
@@ -1539,7 +1560,13 @@ function soPopulatePlayerCards(battingPlayers, bowlingPlayers) {
 
     // Sort by rating
     const sortedBat = [...battingPlayers].sort((a, b) => b.batting_rating - a.batting_rating);
-    const sortedBowl = [...bowlingPlayers].filter(p => p.will_bowl).sort((a, b) => b.bowling_rating - a.bowling_rating);
+    // Prefer designated bowlers, but if the squad has none flagged `will_bowl`
+    // (some TeamProfiles don't), fall back to the whole side — otherwise the
+    // bowler list renders empty and the user can never start the super over.
+    // Mirrors the backend's _select_super_over_bowler fallback.
+    let bowlPool = bowlingPlayers.filter(p => p.will_bowl);
+    if (bowlPool.length === 0) bowlPool = [...bowlingPlayers];
+    const sortedBowl = bowlPool.sort((a, b) => b.bowling_rating - a.bowling_rating);
 
     sortedBat.forEach(p => {
         const card = document.createElement('div');
@@ -1608,6 +1635,21 @@ function soUpdateSelectionCounts() {
 
 // --- Start Innings ---
 function soStartInnings() {
+    // Guard against double-submit: a second click would start a fresh super-over
+    // round on the backend (super_over_round += 1) and desync the state.
+    if (soState._starting) return;
+    soState._starting = true;
+    const startBtn = document.getElementById('so-start-btn');
+    if (startBtn) startBtn.disabled = true;
+
+    const reEnableStart = () => {
+        soState._starting = false;
+        // Only re-enable if a valid selection is still present (modal stayed open).
+        if (startBtn) {
+            startBtn.disabled = !(soState.selectedBatsmen.length === 3 && soState.selectedBowler);
+        }
+    };
+
     const isInnings2 = soState.innings === 2;
     const url = isInnings2
         ? `${window.location.pathname}/start-super-over-innings2`
@@ -1631,8 +1673,13 @@ function soStartInnings() {
             } else {
                 alert(data.error);
             }
+            reEnableStart();
             return;
         }
+
+        // Successful start — clear the in-flight guard (modal closes anyway,
+        // but innings 2 reuses the same soState object and must not stay locked).
+        soState._starting = false;
 
         if (data.target) soState.target = data.target;
 
@@ -1653,16 +1700,38 @@ function soStartInnings() {
 
         // Start simulation in main commentary log
         setTimeout(soSimulateBall, 600);
+    })
+    .catch(err => {
+        // Without this, a dropped request leaves the modal stuck and silent.
+        console.error('Super over start failed:', err);
+        const msg = 'Network error starting the Super Over. Please try again.';
+        if (typeof Toast !== 'undefined' && Toast.show) Toast.show(msg, 'error');
+        else appendLog(`[system_error] ${msg}`, 'error');
+        reEnableStart();
     });
 }
 window.soStartInnings = soStartInnings;
 
 // --- Simulate Ball (commentary in main simulation_log) ---
 function soSimulateBall() {
+    // Prevent overlapping ball requests (duplicate loops / double-advance).
+    if (soState._ballInFlight) return;
+    soState._ballInFlight = true;
+
     fetch(`${window.location.pathname}/next-super-over-ball`, { method: 'POST' })
     .then(r => r.json())
     .then(data => {
-        if (data.error) { console.error(data.error); return; }
+        soState._ballInFlight = false;
+        soState._ballRetries = 0;
+
+        if (data.error) {
+            // Backend error — surface it and offer a manual resume instead of
+            // dying silently in the console (a top user-reported symptom).
+            console.error(data.error);
+            appendLog(`<span style="color:#ef4444;font-weight:700;">Super Over error:</span> ${escapeHtml(data.error)}`, 'comment');
+            soShowResumeButton();
+            return;
+        }
 
         // Only log per-ball commentary when the backend actually delivered a ball.
         // End-of-innings / match-over responses don't carry commentary or score fields.
@@ -1741,7 +1810,39 @@ function soSimulateBall() {
 
         // Normal ball — continue
         setTimeout(soSimulateBall, delay);
+    })
+    .catch(err => {
+        // Without this, a single dropped request froze the super over silently.
+        soState._ballInFlight = false;
+        console.error('Super over ball failed:', err);
+        soState._ballRetries = (soState._ballRetries || 0) + 1;
+        if (soState._ballRetries <= 3) {
+            // Transient blip — back off and retry automatically.
+            appendLog(`<span style="color:#f59e0b;">Connection hiccup — retrying Super Over (${soState._ballRetries}/3)…</span>`, 'comment');
+            setTimeout(soSimulateBall, 1500 * soState._ballRetries);
+        } else {
+            appendLog('<span style="color:#ef4444;font-weight:700;">Super Over stalled.</span> Tap "Resume Super Over" to continue.', 'comment');
+            soShowResumeButton();
+        }
     });
+}
+
+// Floating manual-resume button shown when the super-over loop can't continue
+// on its own (backend error or repeated network failures). Lets the user pick
+// the loop back up without losing the in-memory super-over state.
+function soShowResumeButton() {
+    if (document.getElementById('so-resume-btn')) return;
+    const btn = document.createElement('button');
+    btn.id = 'so-resume-btn';
+    btn.textContent = 'Resume Super Over';
+    btn.style.cssText = 'position:fixed;bottom:20px;left:50%;transform:translateX(-50%);z-index:9999;padding:12px 24px;background:#3b82f6;color:#fff;border:none;border-radius:8px;font-weight:700;cursor:pointer;box-shadow:0 4px 12px rgba(0,0,0,0.3);';
+    btn.onclick = () => {
+        btn.remove();
+        soState._ballRetries = 0;
+        soState._ballInFlight = false;
+        soSimulateBall();
+    };
+    document.body.appendChild(btn);
 }
 
 // Log mini scorecard as text to the main commentary log


### PR DESCRIPTION
## Why

Multiple users reported Super Over failures without reproducible details. A high-level review of the module surfaced four issues that map directly to the most likely symptoms. These are the mandatory hotfixes — low-risk, no redesign.

## What changed

**1. `next_ball()` can no longer corrupt a super over** (`engine/match.py`)
Added an early guard: when `innings >= 4` (super-over pending/decided), `next_ball()` returns a safe `super_over_in_progress` signal instead of falling through to the second-innings-end branch. A stray or resumed normal-ball request (page refresh, duplicate client loop) no longer garbles the result.

**2. Frontend handles the new signal** (`static/js/match_detail.js`, `_processBallResult`)
Halts the normal ball loop on `super_over_in_progress` — routes to the scoreboard if the over is already decided, or prompts a reload if still in progress, instead of spinning on empty responses.

**3. Bowler-selection dead end fixed** (`soPopulatePlayerCards`)
Falls back to the full bowling side when no player has `will_bowl` set (mirrors the backend's `_select_super_over_bowler`). Squads without designated bowlers can now start the super over instead of facing an empty list and a permanently disabled Start button.

**4. Silent freezes + double-submit eliminated** (`soStartInnings`, `soSimulateBall`)
- `.catch` handlers on both fetches with visible toast/log messaging.
- Auto-retry up to 3× with backoff on network blips, then a floating **"Resume Super Over"** button so a stalled over can always be resumed without losing state.
- Backend errors are surfaced in the commentary log instead of dying in the console.
- `_starting` / `_ballInFlight` guards prevent duplicate super-over rounds (`super_over_round += 1` firing twice) and double-counted balls.

## Verification

- `python -c ast.parse` (match.py) and `node --check` (match_detail.js) — both clean.
- `pytest tests/test_match_routes.py -k uper` — **3 passed** (the only super-over tests in the suite).

## Reviewer notes / still open (not in this PR)

This makes a mid-super-over refresh **safe** (no corruption, clear reload prompt) but does **not** yet rehydrate the in-progress over's UI state. Full resume-during-super-over and super-over state persistence across server restarts remain follow-up work, intentionally scoped out of these hotfixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Super Over state management to prevent unintended match continuation in edge cases
  * Fixed duplicate ball response handling during Super Over gameplay
  * Enhanced error recovery with automatic retry mechanism for network failures
  * Added manual recovery option for Super Over continuation if operations encounter issues
  * Strengthened submission controls to prevent accidental duplicate actions during Super Over play

<!-- end of auto-generated comment: release notes by coderabbit.ai -->